### PR TITLE
Show Icons when MatTextField FullWidth="true"

### DIFF
--- a/src/MatBlazor/Components/MatButton/BaseMatButton.cs
+++ b/src/MatBlazor/Components/MatButton/BaseMatButton.cs
@@ -28,9 +28,8 @@ namespace MatBlazor.Components.MatButton
         }
 
         [Parameter]
-        protected Action<UIMouseEventArgs> OnClick { get; set; }
-
-
+        protected EventCallback<UIMouseEventArgs> OnClick { get; set; }
+               
         [Parameter]
         public bool Raised
         {

--- a/src/MatBlazor/Components/MatTextField/MatTextField.cshtml
+++ b/src/MatBlazor/Components/MatTextField/MatTextField.cshtml
@@ -1,7 +1,7 @@
 ﻿@inherits BaseMatTextField
 
 <div class="@ClassMapper.Class" style="@Style" ref="Ref">
-    @if (!FullWidth && Icon != null)
+    @if (Icon != null)
     {
         <i class="material-icons mdc-text-field__icon" tabindex="0">@Icon</i>
     }


### PR DESCRIPTION
Under current code the Icons are not available when using FullWidth. 

`<MatTextField bind-Value="@MyString2" Label="Standard FullWidth" Icon="favorite" FullWidth="true"></MatTextField><br/>
<MatTextField bind-Value="@MyString2" Label="Trailing Required FullWidth" Icon="favorite" IconTrailing="true" FullWidth="true" Required="true"></MatTextField><br/>`