### PR TITLE
MatCheckBox Missing ChildContent, Inherited Base Class Demo

### DIFF
--- a/src/MatBlazor.Demo.App/Pages/DemoInheritedModelPage.cshtml
+++ b/src/MatBlazor.Demo.App/Pages/DemoInheritedModelPage.cshtml
@@ -1,0 +1,8 @@
+﻿@page "/inheritedmodel"
+@inherits DemoInheritedModel
+
+<h2>Base class inheritance for a "code-behind" experience</h2>
+<p>Component files (.cshtml) mix HTML markup and C# processing code in the same file. The @@inherits directive can be used to provide Razor Components apps with a "code-behind" experience that separates component markup from processing code.</p>
+
+<MatCheckbox bind-Checked="@MyCheck" class="filled-in chk-col-blue"></MatCheckbox> <label>@MyCheck</label><br />
+<MatButton OnClick="@MyClick">MatButton</MatButton> <label>@MyString</label>

--- a/src/MatBlazor.Demo.App/Pages/DemoInheritedModelPage.cshtml.cs
+++ b/src/MatBlazor.Demo.App/Pages/DemoInheritedModelPage.cshtml.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Services;
+
+namespace MatBlazor.Demo.App
+{
+    public class DemoInheritedModel : ComponentBase
+    {
+        public bool MyCheck = false;
+        public string MyString = "MatBlazor";
+        private int counter = 1;
+
+        protected async Task MyClick()
+        {
+            await System.Threading.Tasks.Task.Delay(1000);
+            MyString = "MatBlazor Button Clicked " + counter++;
+            return;
+        }
+    }
+}

--- a/src/MatBlazor.Demo.App/Shared/MainLayout.cshtml
+++ b/src/MatBlazor.Demo.App/Shared/MainLayout.cshtml
@@ -33,7 +33,7 @@
         <MatListGroup>
             <MatList SingleSelection="true">
                 <MatListItem Href="@Url.ToAbsoluteUri("").AbsoluteUri">Home</MatListItem>
-                
+
                 <MatListItem Href="@Url.ToAbsoluteUri("BaseMatComponent").AbsoluteUri">
                     BaseMatComponent
                 </MatListItem>
@@ -61,7 +61,7 @@
                 <MatListItem Href="@Url.ToAbsoluteUri("MatSlideToggle").AbsoluteUri">
                     MatSlideToggle
                 </MatListItem>
-                
+
                 <MatListItem Href="@Url.ToAbsoluteUri("MatDrawer").AbsoluteUri">
                     MatDrawer
                 </MatListItem>
@@ -71,7 +71,7 @@
                 <MatListItem Href="@Url.ToAbsoluteUri("MatMenu").AbsoluteUri">
                     MatMenu
                 </MatListItem>
-                
+
                 <MatListItem Href="@Url.ToAbsoluteUri("MatCard").AbsoluteUri">
                     MatCard
                 </MatListItem>
@@ -81,7 +81,7 @@
                 <MatListItem Href="@Url.ToAbsoluteUri("MatList").AbsoluteUri">
                     MatList
                 </MatListItem>
-                
+
                 <MatListItem Href="@Url.ToAbsoluteUri("MatButton").AbsoluteUri">
                     MatButton
                 </MatListItem>
@@ -96,6 +96,10 @@
                 </MatListItem>
                 <MatListItem Href="@Url.ToAbsoluteUri("Typography").AbsoluteUri">
                     Typography
+                </MatListItem>
+
+                <MatListItem Href="@Url.ToAbsoluteUri("InheritedModel").AbsoluteUri">
+                    Demo Inherited Page Model
                 </MatListItem>
             </MatList>
         </MatListGroup>

--- a/src/MatBlazor.TestApp/Pages/InheritedModelPage.cshtml
+++ b/src/MatBlazor.TestApp/Pages/InheritedModelPage.cshtml
@@ -1,0 +1,9 @@
+﻿@page "/inheritedmodel"
+@inherits InheritedModel
+@layout MainLayout
+
+    <h2>Base class inheritance for a "code-behind" experience</h2>
+    <p>Component files (.cshtml) mix HTML markup and C# processing code in the same file. The @@inherits directive can be used to provide Razor Components apps with a "code-behind" experience that separates component markup from processing code.</p>
+
+    <MatCheckbox bind-Checked="@MyCheck" class="filled-in chk-col-blue"></MatCheckbox> <label>@MyCheck</label><br/>
+    <MatButton OnClick="@MyClick">MatButton</MatButton> <label>@MyString</label>

--- a/src/MatBlazor.TestApp/Pages/InheritedModelPage.cshtml.cs
+++ b/src/MatBlazor.TestApp/Pages/InheritedModelPage.cshtml.cs
@@ -1,0 +1,20 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Services;
+
+namespace MatBlazor.TestApp.Pages
+{
+    public class InheritedModel : ComponentBase
+    {
+        public bool MyCheck = false;
+        public string MyString = "MatBlazor";
+        private int counter = 1;
+        protected async Task MyClick()
+        {
+            await System.Threading.Tasks.Task.Delay(1000);
+            MyString = "MatBlazor Button Clicked " + counter++;
+            return;
+        }
+    }
+}

--- a/src/MatBlazor.TestApp/Shared/NavMenu.cshtml
+++ b/src/MatBlazor.TestApp/Shared/NavMenu.cshtml
@@ -23,6 +23,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="inheritedmodel">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Inherited Class
+            </NavLink>
+        </li>
     </ul>
 </div>
 

--- a/src/MatBlazor/Components/MatCheckbox/BaseMatCheckbox.cs
+++ b/src/MatBlazor/Components/MatCheckbox/BaseMatCheckbox.cs
@@ -18,6 +18,9 @@ namespace MatBlazor.Components.MatCheckbox
         }
 
         [Parameter]
+        private RenderFragment ChildContent { get; set; }
+
+        [Parameter]
         public bool Checked { get; set; }
 
         [Parameter]


### PR DESCRIPTION
#41 Fixed MatCheckBox missing ChildContent parameter.

Added demo pages to test out Component Base Class pages for MatBlazor components so that we do not have to recreate this type of page for testing.