### PR TITLE
Prevent *.razor files from being packed

### DIFF
--- a/src/MatBlazor/MatBlazor.csproj
+++ b/src/MatBlazor/MatBlazor.csproj
@@ -6,18 +6,18 @@
     <IsPackable>true</IsPackable>   
     <LangVersion>8.0</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <Description>Material Design components for Blazor and Razor Components</Description>
     <PackageProjectUrl>https://www.matblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BlazorComponents/MatBlazor</RepositoryUrl>
     <PackageTags>blazor,mat,material, design, razor, components</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>0.9.3.0</AssemblyVersion>
+    <AssemblyVersion>0.9.4.0</AssemblyVersion>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>Vladimir Samoilenko</Copyright>
-    <FileVersion>0.9.3.0</FileVersion>
+    <FileVersion>0.9.4.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Vladimir Samoilenko</Authors>
@@ -45,7 +45,9 @@
   </ItemGroup>
 
   <ItemGroup>
-   
+    <Content Update="*.razor">
+      <Pack>false</Pack>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implements workaround for issue https://github.com/aspnet/AspNetCore/issues/9577

This will prevent MatBlazor .razor files from showing up in the project
![image](https://user-images.githubusercontent.com/9521987/56528909-c7ed4100-6504-11e9-8b93-5557953951ec.png)
